### PR TITLE
Add `quoteKeys` option, use `options` property

### DIFF
--- a/addon/components/entry-viewer.js
+++ b/addon/components/entry-viewer.js
@@ -1,6 +1,7 @@
 import Component from "@ember/component";
 import { computed } from "@ember/object";
 import layout from "../templates/components/entry-viewer";
+import { readOnly } from "@ember/object/computed";
 
 function isArray(v) {
   return Array.isArray(v);
@@ -22,19 +23,37 @@ export default Component.extend({
     }
     let depth = this.get("depth");
     let collapseDepth = this.get("collapseDepth");
-    if (collapseDepth === null) {
-      return true;
-    } else {
+    if (Number.isInteger(collapseDepth)) {
       return depth < collapseDepth;
+    } else {
+      return true;
     }
   }),
 
   // passed-in
-  collapseDepth: null, // when not specified, all entries are expanded
   value: null,
   depth: 0,
-  expandedIcon: null,
-  collapsedIcon: null,
+
+  collapseDepth: readOnly("displayOptions.collapseDepth"),
+  expandedIcon: readOnly("displayOptions.expandedIcon"),
+  collapsedIcon: readOnly("displayOptions.collapsedIcon"),
+  quoteKeys: readOnly("displayOptions.quoteKeys"),
+
+  keyPrefix: computed("quoteKeys", function () {
+    if (this.get("quoteKeys")) {
+      return '"';
+    } else {
+      return "";
+    }
+  }),
+
+  keySuffix: computed("quoteKeys", function () {
+    if (this.get("quoteKeys")) {
+      return '"';
+    } else {
+      return "";
+    }
+  }),
 
   isToggleable: computed("showInline", "value", function () {
     if (this.get("showInline")) {

--- a/addon/components/json-viewer.js
+++ b/addon/components/json-viewer.js
@@ -1,12 +1,27 @@
 import Component from "@ember/component";
 import layout from "../templates/components/json-viewer";
+import { assert } from "@ember/debug";
+
+const ALLOWED_OPTIONS = [
+  "expandedIcon",
+  "collapsedIcon",
+  "collapseDepth",
+  "quoteKeys",
+];
 
 export default Component.extend({
   tagName: "",
   layout,
 
-  // Can be overridden
-  expandedIcon: "+",
-  collapsedIcon: "-",
-  collapseDepth: null, // indicates all nodes are expanded
+  init() {
+    this._super(...arguments);
+
+    let options = this.get("options") || {};
+    assert(
+      `Only allowed options are: ${ALLOWED_OPTIONS}`,
+      Object.keys(options).every((key) => ALLOWED_OPTIONS.includes(key))
+    );
+
+    this.set("displayOptions", options);
+  },
 });

--- a/addon/components/value-viewer.js
+++ b/addon/components/value-viewer.js
@@ -12,6 +12,8 @@ export default Component.extend({
 
   // passed-in
   value: null,
+  showSummary: false,
+  showInline: false,
 
   isPrimitive: computed("value", function () {
     return isPrimitive(this.get("value"));

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -38,13 +38,16 @@
 
 .key.is-toggleable {
   cursor: pointer;
-  user-select: none;
   position: relative;
 }
 
 .key.is-toggleable .key-expansion-state {
   position: absolute;
   left: -15px;
+}
+
+.key-expansion-state {
+  user-select: none;
 }
 
 .syntax-key {

--- a/addon/templates/components/entry-viewer.hbs
+++ b/addon/templates/components/entry-viewer.hbs
@@ -8,20 +8,19 @@
           {{{this.collapsedIcon}}}
         {{/if}}
       </span>
-      {{this.key}}:
+      {{this.keyPrefix}}{{this.key}}{{this.keySuffix}}:
     </span>
   {{else}}
     <span class="key">
-      {{this.key}}:
+      {{this.keyPrefix}}{{this.key}}{{this.keySuffix}}:
     </span>
   {{/if}}
   {{value-viewer
-    value=value showSummary=(not this.isExpanded)
-    depth=(inc depth)
+    value=this.value
+    showSummary=(not this.isExpanded)
+    depth=(inc this.depth)
     showInline=this.showInline
-    expandedIcon=this.expandedIcon
-    collapsedIcon=this.collapsedIcon
-    collapseDepth=this.collapseDepth
+    displayOptions=this.displayOptions
   }}
   <span class="entry-delimiter">
     ,

--- a/addon/templates/components/json-viewer.hbs
+++ b/addon/templates/components/json-viewer.hbs
@@ -2,8 +2,6 @@
   {{value-viewer
     value=this.json
     depth=0
-    expandedIcon=this.expandedIcon
-    collapsedIcon=this.collapsedIcon
-    collapseDepth=this.collapseDepth
+    displayOptions=this.displayOptions
   }}
 </div>

--- a/addon/templates/components/value-viewer.hbs
+++ b/addon/templates/components/value-viewer.hbs
@@ -18,10 +18,8 @@
           {{entry-viewer
             key=key
             value=value
-            depth=depth
-            expandedIcon=this.expandedIcon
-            collapsedIcon=this.collapsedIcon
-            collapseDepth=this.collapseDepth
+            depth=this.depth
+            displayOptions=this.displayOptions
           }}
         {{/each-in}}
       {{else}}
@@ -29,10 +27,8 @@
           <li class="entry">
             {{value-viewer
               value=value
-              depth=depth
-              expandedIcon=this.expandedIcon
-              collapsedIcon=this.collapsedIcon
-              collapseDepth=this.collapseDepth
+              depth=this.depth
+              displayOptions=this.displayOptions
             }}
             <span class="entry-delimiter">
               ,

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -2,7 +2,7 @@
   <h2 id="title">Ember-JSON-Viewer</h2>
 
   <div class="viewer-wrapper">
-    <JsonViewer @json={{this.json}} @expandedIcon="+" @collapsedIcon="-" @collapseDepth={{3}} />
+    <JsonViewer @json={{this.json}} @options={{hash expandedIcon=">" collapsedIcon="<" collapseDepth=5 quoteKeys=true}} />
   </div>
   <div class="input-wrapper {{if this.isJSONVAlid "valid" "invalid"}}">
     <h2>Paste JSON below:</h2>


### PR DESCRIPTION
Pass all options to json-viewer in a hash.
Adds a 'quoteKeys' option that toggles the '"" around keys.

Make the expansion-state icon not user-selectable, and the key user-selectable
so that copying and pasting the HTML results in valid JSON (when quoteKeys is true).