### PR TITLE
Indent using spaces, copied JSON should be identical to text displayed in UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+
+# IDE stuff
+/.idea/

--- a/addon/components/entry-viewer.js
+++ b/addon/components/entry-viewer.js
@@ -37,6 +37,7 @@ export default Component.extend({
   collapseDepth: readOnly("displayOptions.collapseDepth"),
   expandedIcon: readOnly("displayOptions.expandedIcon"),
   collapsedIcon: readOnly("displayOptions.collapsedIcon"),
+  showIcons: readOnly("displayOptions.showIcons"),
   quoteKeys: readOnly("displayOptions.quoteKeys"),
 
   keyPrefix: computed("quoteKeys", function () {

--- a/addon/components/json-viewer.js
+++ b/addon/components/json-viewer.js
@@ -6,6 +6,7 @@ const ALLOWED_OPTIONS = [
   "expandedIcon",
   "collapsedIcon",
   "collapseDepth",
+  "showIcons",
   "quoteKeys",
 ];
 

--- a/addon/components/value-viewer.js
+++ b/addon/components/value-viewer.js
@@ -46,4 +46,20 @@ export default Component.extend({
 
     return count;
   }),
+
+  indentation: computed("depth", function() {
+    let ret = "";
+    for (let i = 0; i <= this.get("depth"); ++i) {
+      ret += "  ";
+    }
+    return ret;
+  }),
+
+  suffixIndentation: computed("depth", function() {
+    let ret = "";
+    for (let i = 0; i < this.get("depth"); ++i) {
+      ret += "  ";
+    }
+    return ret;
+  })
 });

--- a/addon/components/value-viewer.js
+++ b/addon/components/value-viewer.js
@@ -48,18 +48,10 @@ export default Component.extend({
   }),
 
   indentation: computed("depth", function() {
-    let ret = "";
-    for (let i = 0; i <= this.get("depth"); ++i) {
-      ret += "  ";
-    }
-    return ret;
+    return "".padStart((this.get('depth') + 1) * 2 , " ");
   }),
 
   suffixIndentation: computed("depth", function() {
-    let ret = "";
-    for (let i = 0; i < this.get("depth"); ++i) {
-      ret += "  ";
-    }
-    return ret;
+    return "".padStart(this.get('depth') * 2, " ");
   })
 });

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -10,8 +10,6 @@
 }
 
 .entries {
-  /*list-style: none;*/
-  /*padding-inline-start: 1.25em;*/
   margin: 0;
   display: block;
 }
@@ -45,7 +43,6 @@
 .key.is-toggleable .key-expansion-state {
   position: absolute;
   left: -15px;
-  top: 0px;
 }
 
 .key-expansion-state {

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -10,9 +10,10 @@
 }
 
 .entries {
-  list-style: none;
-  padding-inline-start: 1.25em;
+  /*list-style: none;*/
+  /*padding-inline-start: 1.25em;*/
   margin: 0;
+  display: block;
 }
 
 .entries.entries-inline,
@@ -36,6 +37,10 @@
   color: #666;
 }
 
+.entry-body {
+  display:inline;
+}
+
 .key.is-toggleable {
   cursor: pointer;
   position: relative;
@@ -44,6 +49,7 @@
 .key.is-toggleable .key-expansion-state {
   position: absolute;
   left: -15px;
+  top: 0px;
 }
 
 .key-expansion-state {
@@ -69,4 +75,22 @@
 .syntax-unknown {
   color: red;
   font-size: large;
+}
+
+.closing-bracket {
+  display: inline-block;
+}
+
+pre {
+  display: inline;
+  padding: 0px;
+  margin: 0 0 0 0px;
+  font-size: inherit;
+  line-height: inherit;
+  word-break: inherit;
+  word-wrap: inherit;
+  color: inherit;
+  background-color: transparent;
+  border: none;
+  border-radius: inherit;
 }

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -22,10 +22,6 @@
   display: inline-block;
 }
 
-.entry-delimiter {
-  margin-left: -8px;
-}
-
 /* Hide the delimiter after the last item. It is
    vald to have a trailing comma in a JavaScript object/array,
    but not in JSON. */

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -42,6 +42,7 @@
 
 .key.is-toggleable .key-expansion-state {
   position: absolute;
+  line-height: 28px;
   left: -15px;
 }
 

--- a/addon/templates/components/entry-viewer.hbs
+++ b/addon/templates/components/entry-viewer.hbs
@@ -1,4 +1,4 @@
-<li class="entry">
+<div class="entry-body">
   {{#if this.isToggleable}}
     <span class="key is-toggleable" {{action "toggleExpanded"}}>
       <span class="key-expansion-state">
@@ -22,7 +22,4 @@
     showInline=this.showInline
     displayOptions=this.displayOptions
   }}
-  <span class="entry-delimiter">
-    ,
-  </span>
-</li>
+</div>

--- a/addon/templates/components/entry-viewer.hbs
+++ b/addon/templates/components/entry-viewer.hbs
@@ -1,25 +1,19 @@
 <div class="entry-body">
-  {{#if this.isToggleable}}
-    <span class="key is-toggleable" {{action "toggleExpanded"}}>
-      <span class="key-expansion-state">
-        {{#if this.isExpanded}}
-          {{{this.expandedIcon}}}
-        {{else}}
-          {{{this.collapsedIcon}}}
-        {{/if}}
-      </span>
-      {{this.keyPrefix}}{{this.key}}{{this.keySuffix}}:
-    </span>
-  {{else}}
-    <span class="key">
-      {{this.keyPrefix}}{{this.key}}{{this.keySuffix}}:
-    </span>
-  {{/if}}
+  {{~#if this.isToggleable~}}
+    <span class="key is-toggleable" {{action "toggleExpanded"}}><span class="key-expansion-state">
+      {{#if this.isExpanded}}
+        {{{this.expandedIcon}}}
+      {{else}}
+        {{{this.collapsedIcon}}}
+      {{/if}}</span>{{this.keyPrefix}}{{this.key}}{{this.keySuffix}}: </span>
+  {{~else~}}
+    <span class="key">{{this.keyPrefix}}{{this.key}}{{this.keySuffix}}: </span>
+  {{~/if}}
   {{value-viewer
-    value=this.value
-    showSummary=(not this.isExpanded)
-    depth=(inc this.depth)
-    showInline=this.showInline
-    displayOptions=this.displayOptions
-  }}
+          value=this.value
+          showSummary=(not this.isExpanded)
+          depth=(inc this.depth)
+          showInline=this.showInline
+          displayOptions=this.displayOptions
+  ~}}
 </div>

--- a/addon/templates/components/entry-viewer.hbs
+++ b/addon/templates/components/entry-viewer.hbs
@@ -1,10 +1,12 @@
 <div class="entry-body">
   {{~#if this.isToggleable~}}
     <span class="key is-toggleable" {{action "toggleExpanded"}}><span class="key-expansion-state">
-      {{#if this.isExpanded}}
-        {{{this.expandedIcon}}}
-      {{else}}
-        {{{this.collapsedIcon}}}
+      {{# if this.showIcons}}
+        {{#if this.isExpanded}}
+          <i class="fa fa-caret-down" aria-hidden="true"></i>
+        {{else}}
+          <i class="fa fa-caret-right" aria-hidden="true"></i>
+        {{/if}}
       {{/if}}</span>{{this.keyPrefix}}{{this.key}}{{this.keySuffix}}: </span>
   {{~else~}}
     <span class="key">{{this.keyPrefix}}{{this.key}}{{this.keySuffix}}: </span>

--- a/addon/templates/components/simple-value.hbs
+++ b/addon/templates/components/simple-value.hbs
@@ -1,3 +1,1 @@
-<span class="value primitive {{this.syntaxClass}}">
-  {{this.formattedValue}}
-</span>
+<span class="value primitive {{this.syntaxClass}}">{{this.formattedValue}}</span>

--- a/addon/templates/components/value-viewer.hbs
+++ b/addon/templates/components/value-viewer.hbs
@@ -12,34 +12,40 @@
       {{this.valueSummary}}
     </span>
   {{else}}
-    <ul class="entries depth-{{depth}} {{if this.showInline "entries-inline"}}">
+    <div class="entries">
       {{#if this.isObj}}
         {{#each-in value as |key value|}}
-          {{entry-viewer
-            key=key
-            value=value
-            depth=this.depth
-            displayOptions=this.displayOptions
-          }}
-        {{/each-in}}
-      {{else}}
-        {{#each value as |value|}}
-          <li class="entry">
-            {{value-viewer
+          <div class="entry">
+            <pre><span>{{this.indentation}}</span></pre>
+            {{entry-viewer
+              key=key
               value=value
               depth=this.depth
               displayOptions=this.displayOptions
-            }}
-            <span class="entry-delimiter">
-              ,
-            </span>
-          </li>
+            }}<span class="entry-delimiter"> , </span>
+          </div>
+        {{/each-in}}
+      {{else}}
+        {{#each value as |value|}}
+          <div class="entry">
+            <pre><span>{{this.indentation}}</span></pre>
+            {{value-viewer
+              value=value
+              depth=(inc this.depth)
+              displayOptions=this.displayOptions
+            }}<span class="entry-delimiter"> , </span>
+          </div>
         {{/each}}
       {{/if}}
-    </ul>
+    </div>
   {{/if}}
 
-  <span class="suffix">
-    {{this.suffix}}
-  </span>
+  <div class="closing-bracket">
+    {{#unless this.showSummary}}
+      <pre><span>{{this.suffixIndentation}}</span></pre>
+    {{/unless}}
+    <span class="suffix">
+      {{this.suffix}}
+    </span>
+  </div>
 {{/if}}

--- a/addon/templates/components/value-viewer.hbs
+++ b/addon/templates/components/value-viewer.hbs
@@ -1,51 +1,41 @@
-{{#if this.isPrimitive}}
-  <span class="value primitive">
-    {{simple-value value=this.value}}
-  </span>
-{{else}}
-  <span class="prefix">
-    {{this.prefix}}
-  </span>
-
-  {{#if this.showSummary}}
-    <span class="entries-summary">
-      {{this.valueSummary}}
-    </span>
-  {{else}}
+{{#if this.isPrimitive~}}
+  <span class="value primitive">{{simple-value value=this.value}}</span>
+{{~else~}}
+  <span class="prefix">{{this.prefix}}</span>
+  {{~# if this.showSummary~}}
+    <span class="entries-summary">{{this.valueSummary}}</span>
+  {{~else}}
     <div class="entries">
       {{#if this.isObj}}
-        {{#each-in value as |key value|}}
+        {{#each-in value as |key value|~}}
           <div class="entry">
             <pre><span>{{this.indentation}}</span></pre>
-            {{entry-viewer
-              key=key
-              value=value
-              depth=this.depth
-              displayOptions=this.displayOptions
-            }}<span class="entry-delimiter"> , </span>
+            {{~entry-viewer
+                    key=key
+                    value=value
+                    depth=this.depth
+                    displayOptions=this.displayOptions
+            ~}}
+            <span class="entry-delimiter">, </span>
           </div>
-        {{/each-in}}
-      {{else}}
-        {{#each value as |value|}}
+        {{~/each-in}}
+      {{~ else ~}}
+        {{#each value as |value| ~}}
           <div class="entry">
             <pre><span>{{this.indentation}}</span></pre>
-            {{value-viewer
-              value=value
-              depth=(inc this.depth)
-              displayOptions=this.displayOptions
-            }}<span class="entry-delimiter"> , </span>
-          </div>
-        {{/each}}
-      {{/if}}
+            {{~value-viewer
+                    value=value
+                    depth=(inc this.depth)
+                    displayOptions=this.displayOptions
+            ~}}
+            <span class="entry-delimiter">, </span>
+          </div>{{/each}}
+      {{~/if}}
     </div>
-  {{/if}}
-
+  {{~/if ~}}
   <div class="closing-bracket">
-    {{#unless this.showSummary}}
+    {{~#unless this.showSummary ~}}
       <pre><span>{{this.suffixIndentation}}</span></pre>
-    {{/unless}}
-    <span class="suffix">
-      {{this.suffix}}
-    </span>
-  </div>
-{{/if}}
+    {{~/unless~}}
+    <span class="suffix">{{this.suffix}}</span></div>
+{{~/if~}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -2,7 +2,7 @@
   <h2 id="title">Ember-JSON-Viewer</h2>
 
   <div class="viewer-wrapper">
-    <JsonViewer @json={{this.json}} @options={{hash expandedIcon=">" collapsedIcon="<" collapseDepth=5 quoteKeys=true}} />
+    <JsonViewer @json={{this.json}} @options={{hash expandedIcon=">" collapsedIcon="<" collapseDepth=5 quoteKeys=true showIcons=true}} />
   </div>
   <div class="input-wrapper {{if this.isJSONVAlid "valid" "invalid"}}">
     <h2>Paste JSON below:</h2>


### PR DESCRIPTION
## Description
This PR makes the following changes: 
- edit the json viewer to pad each level indentation using spaces instead of css "padding" property on List Item elements
- remove space in front of each entry delimiter (comma). Currently this is done visually by giving it a negative margin, but we need to this space to be removed entirely so that copy + paste is consistent
- remove additional spacing between summary message
- manually selecting and copy+pasting the json should produce the same formatting and content as seen in the UI
- set fa expanding and closing icons in the template file instead of passing in an html string 

Note: Inline arrays is no longer supported... the closing bracket will always display on the next line: 
```
"emptyArray": [
]
```
instead of 
```
"emptyArray: []
```
## Changes
Copied text before: 
```
"stringArrayKey": [
"one" ,
"two" ,
"three" ,
"stringValue1" ,
"stringValue2" ,
"stringValue3"] ,
```
Copied text after: 
```
  "stringArrayKey": [
    "one",
    "two",
    "three",
    "stringValue1",
    "stringValue2",
    "stringValue3"
  ],
```

Summary message before: 
![image](https://user-images.githubusercontent.com/19659625/102837693-5137d380-43ca-11eb-9638-62507778a79a.png)
Summary message after: 
![image](https://user-images.githubusercontent.com/19659625/102837624-2ea5ba80-43ca-11eb-8407-2076f5f8941d.png)
