### PR TITLE
Support `null` values

### DIFF
--- a/addon/components/simple-value.js
+++ b/addon/components/simple-value.js
@@ -15,11 +15,13 @@ export default Component.extend({
   type: computed("value", function () {
     let v = this.get("value");
     return [true, false].includes(v)
-      ? "literal"
+      ? "boolean"
       : Number.isFinite(v)
       ? "number"
       : typeof v === "string"
       ? "string"
+      : v === null
+      ? "null"
       : "unknown";
   }),
 
@@ -27,6 +29,8 @@ export default Component.extend({
     let v = this.get("value");
     if (this.get("type") === "string") {
       return `"${v}"`;
+    } else if (this.get("type") === "null") {
+      return `null`;
     } else {
       return v;
     }

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -46,7 +46,11 @@
   color: green;
 }
 
-.syntax-literal {
+.syntax-boolean {
+  color: #32aaee;
+}
+
+.syntax-null {
   color: #32aaee;
 }
 

--- a/addon/utils/value-types.js
+++ b/addon/utils/value-types.js
@@ -3,7 +3,7 @@ export function isArray(v) {
 }
 
 export function isPrimitive(v) {
-  return ["number", "boolean", "string"].includes(typeof v);
+  return v === null || ["number", "boolean", "string"].includes(typeof v);
 }
 
 export function isObject(v) {

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -6,6 +6,7 @@ const DEFAULT_JSON = {
   stringKey: "stringValue",
   numberKey: 123,
   numArrayKey: [1, 2, 3],
+  includeNull: [1, null, "two", false],
   mixedKey: ["one", 2.1234, "three point four five 6", 7.891],
   stringArrayKey: [
     "one",
@@ -60,16 +61,16 @@ export default class ApplicationController extends Controller {
   json = DEFAULT_JSON;
 
   @tracked
-  isJSONVAlid = true;
+  isJSONValid = true;
 
   @action updateJSON(evt) {
     try {
       let v = JSON.parse(evt.target.value);
       this.json = v;
-      this.isJSONVAlid = true;
+      this.isJSONValid = true;
     } catch (e) {
       // ignore unparseable json
-      this.isJSONVAlid = false;
+      this.isJSONValid = false;
     }
   }
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -4,7 +4,7 @@
   <div class="viewer-wrapper">
     <JsonViewer @json={{this.json}} @options={{hash expandedIcon=">" collapsedIcon="<" collapseDepth=5}} />
   </div>
-  <div class="input-wrapper {{if this.isJSONVAlid "valid" "invalid"}}">
+  <div class="input-wrapper {{if this.isJSONValid "valid" "invalid"}}">
     <h2>Paste JSON below:</h2>
     <Textarea oninput={{action this.updateJSON}} @value={{json-stringify this.json}} />
   </div>

--- a/tests/unit/utils/json-stringify-test.js
+++ b/tests/unit/utils/json-stringify-test.js
@@ -32,6 +32,10 @@ const JSONS = {
       },
     },
   },
+  has_null: {
+    x: null,
+    y: [null, null],
+  },
 };
 
 function nativeJsonStringify(json) {
@@ -755,6 +759,80 @@ module("Unit | Utility | json-stringify", function () {
       jsonStringify(json, range),
       format(expected),
       `when JSON includes MARKER constant`
+    );
+  });
+
+  test("serializes `null` correctly", function (assert) {
+    let expected = `{
+    ->«"x": n»ull,
+    ->"y": [
+    ->->null,
+    ->->null,
+    ->]
+    }`;
+    let range = {
+      start: { path: "$.x", index: 0 },
+      end: { path: "$.x@", index: 1 },
+    };
+
+    assert.equal(
+      jsonStringify(JSONS.has_null, range),
+      format(expected),
+      `with range ${JSON.stringify(range)}`
+    );
+
+    expected = `{
+    ->«"x": nu»ll,
+    ->"y": [
+    ->->null,
+    ->->null,
+    ->]
+    }`;
+    range = {
+      start: { path: "$.x", index: 0 },
+      end: { path: "$.x@", index: 2 },
+    };
+
+    assert.equal(
+      jsonStringify(JSONS.has_null, range),
+      format(expected),
+      `with range ${JSON.stringify(range)}`
+    );
+
+    expected = `{
+    ->«"x": null»,
+    ->"y": [
+    ->->null,
+    ->->null,
+    ->]
+    }`;
+    range = {
+      start: { path: "$.x", index: 0 },
+      end: { path: "$.x@", index: 4 },
+    };
+
+    assert.equal(
+      jsonStringify(JSONS.has_null, range),
+      format(expected),
+      `with range ${JSON.stringify(range)}`
+    );
+
+    expected = `{
+    ->«"x": null,»
+    ->"y": [
+    ->->null,
+    ->->null,
+    ->]
+    }`;
+    range = {
+      start: { path: "$.x", index: 0 },
+      end: { path: "$.x@,", index: 1 },
+    };
+
+    assert.equal(
+      jsonStringify(JSONS.has_null, range),
+      format(expected),
+      `with range ${JSON.stringify(range)}`
     );
   });
 });


### PR DESCRIPTION
Prior to this, `null` was incorrectly treated as an empty object,
because `typeof null === 'object'`.

Was reading https://2ality.com/2021/01/undefined-null-revisited.html and realized that ember-json-viewer forgot that `null` is a valid value in JSON.