### PR TITLE
Address deprecations

### DIFF
--- a/addon/components/entry-viewer.js
+++ b/addon/components/entry-viewer.js
@@ -7,13 +7,20 @@ import { isPrimitive } from "../utils/value-types";
 export default Component.extend({
   tagName: "",
   layout,
-  isExpanded: computed("depth", "collapseDepth", function () {
-    let depth = this.get("depth");
-    let collapseDepth = this.get("collapseDepth");
-    if (Number.isInteger(collapseDepth)) {
-      return depth < collapseDepth;
-    } else {
-      return true;
+  isExpanded: computed("depth", "collapseDepth",  {
+    get() {
+      let depth = this.get("depth");
+      let collapseDepth = this.get("collapseDepth");
+      if (Number.isInteger(collapseDepth)) {
+        this._isExpanded = depth < collapseDepth;
+        return this._isExpanded;
+      } else {
+        this._isExpanded = true;
+        return this._isExpanded;
+      }
+    },
+    set(key, value) {
+      return this._isExpanded = value;
     }
   }),
 


### PR DESCRIPTION
We were getting deprecation warnings for setting a computed property.  This should get rid of those warnings because the computed properties are being handled by a getter and setter.

Also, I did `npm audit fix` to hopefully fix some dependency issues.