### PR TITLE
Add static security scanning with CodeQL (SAST)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: "Static security scanning"
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main, master]
+    paths:
+      - '**.js'
+  schedule:
+    # Timezone: UTC
+    #        ┌───────────── minute (0 - 59)
+    #        │  ┌───────────── hour (0 - 23)
+    #        │  │ ┌───────────── day of the month (1 - 31)
+    #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        *  * * * *
+    - cron: '30 0 * * 0'
+jobs:
+  run:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    permissions:
+      # required for all workflows:
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['javascript']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v2

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const getChannelURL = require("ember-source-channel-url");
-
 module.exports = async function () {
   return {
     useYarn: true,
@@ -19,30 +17,6 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             "ember-source": "~3.20.5",
-          },
-        },
-      },
-      {
-        name: "ember-release",
-        npm: {
-          devDependencies: {
-            "ember-source": await getChannelURL("release"),
-          },
-        },
-      },
-      {
-        name: "ember-beta",
-        npm: {
-          devDependencies: {
-            "ember-source": await getChannelURL("beta"),
-          },
-        },
-      },
-      {
-        name: "ember-canary",
-        npm: {
-          devDependencies: {
-            "ember-source": await getChannelURL("canary"),
           },
         },
       },


### PR DESCRIPTION
Enables weekly CodeQL scans in addition to scans on pull requests.