### PR TITLE
Templates: Curly->Angle invocation, add ember-template-lint

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -2,4 +2,8 @@
 
 module.exports = {
   extends: 'octane',
+  rules: {
+    'no-triple-curlies': false,
+    'no-invalid-interactive': false,
+  },
 };

--- a/addon/templates/components/entry-viewer.hbs
+++ b/addon/templates/components/entry-viewer.hbs
@@ -1,6 +1,6 @@
 <li class="entry">
   {{#if this.isToggleable}}
-    <span class="key is-toggleable" {{action "toggleExpanded"}} data-test-toggle={{this.path}}>
+    <span class="key is-toggleable" {{on "click" this.toggleExpanded}} data-test-toggle={{this.path}}>
       <span class="key-expansion-state">
         {{#if this.isExpanded}}
           {{{this.expandedIcon}}}
@@ -23,13 +23,13 @@
       {{this.quotedKey}}
     </span>
   {{/if}}
-  {{value-viewer
-    value=this.value
-    showSummary=(not this.isExpanded)
-    depth=(inc this.depth)
-    displayOptions=this.displayOptions
-    path=this.path
-  }}
+  <ValueViewer
+    @value={{this.value}}
+    @showSummary={{not this.isExpanded}}
+    @depth={{inc this.depth}}
+    @displayOptions={{this.displayOptions}}
+    @path={{this.path}}
+  />
   {{#unless this.isLast}}
     {{! In order for copy/paste to work, there cannot be extra whitespace around the delimiter }}
     <span class="entry-delimiter" data-path={{concat this.path "@" ","}}>,</span>

--- a/addon/templates/components/json-viewer.hbs
+++ b/addon/templates/components/json-viewer.hbs
@@ -1,6 +1,6 @@
-{{value-viewer
-  value=this.json
-  depth=0
-  displayOptions=this.displayOptions
-  path="$"
-}}
+<ValueViewer
+  @value={{this.json}}
+  @depth={{0}}
+  @displayOptions={{this.displayOptions}}
+  @path={{"$"}}
+/>

--- a/addon/templates/components/value-viewer.hbs
+++ b/addon/templates/components/value-viewer.hbs
@@ -1,6 +1,6 @@
 {{#if this.isPrimitive}}
   <span class="value primitive">
-    {{simple-value value=this.value path=(concat this.path "@")}}
+    <SimpleValue @value={{this.value}} @path={{concat this.path "@"}} />
   </span>
 {{else}}
   <span class="prefix" data-path={{concat this.path "<"}}>
@@ -15,28 +15,28 @@
     <ul class="entries depth-{{this.depth}}">
       {{#if this.isObj}}
         {{#each-in this.value as |key innerValue|}}
-          {{entry-viewer
-            key=key
-            value=innerValue
-            depth=this.depth
-            path=(concat this.path "." key)
-            displayOptions=this.displayOptions
-            isLast=(is-last this.value key)
-          }}
+          <EntryViewer
+            @key={{key}}
+            @value={{innerValue}}
+            @depth={{this.depth}}
+            @path={{concat this.path "." key}}
+            @displayOptions={{this.displayOptions}}
+            @isLast={{is-last this.value key}}
+          />
         {{/each-in}}
       {{else}}
         {{#each this.value as |innerValue index|}}
           <li class="entry">
-            {{value-viewer
-              value=innerValue
-              depth=this.depth
-              path=(concat this.path "[" index "]")
-              displayOptions=this.displayOptions
-            }}
-            {{#unless (is-last this.value index)}}
+            <ValueViewer
+              @value={{innerValue}}
+              @depth={{this.depth}}
+              @path={{concat this.path "[" index "]"}}
+              @displayOptions={{this.displayOptions}}
+            />
+            {{#if (not (is-last this.value index))}}
               {{! In order for copy/paste to work, there cannot be extra whitespace around the delimiter }}
               <span class="entry-delimiter" data-path={{concat this.path "[" index "]" "@" ","}}>,</span>
-            {{/unless}}
+            {{/if}}
           </li>
         {{/each}}
       {{/if}}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "ember build --environment=production",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*",
     "lint:js": "eslint .",
+    "lint:hbs": "ember-template-lint .",
     "start": "ember serve",
     "test": "npm-run-all lint:* test:*",
     "test:ember": "ember test",

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -56,21 +56,36 @@ const DEFAULT_JSON = {
   },
 };
 
+function isParseable(json) {
+  try {
+    JSON.parse(json);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
 export default class ApplicationController extends Controller {
   @tracked
-  json = DEFAULT_JSON;
+  sourceJSONStr = JSON.stringify(DEFAULT_JSON, null, 2);
+
+  @tracked
+  viewJSON = DEFAULT_JSON;
 
   @tracked
   isJSONValid = true;
 
-  @action updateJSON(evt) {
-    try {
-      let v = JSON.parse(evt.target.value);
-      this.json = v;
-      this.isJSONValid = true;
-    } catch (e) {
-      // ignore unparseable json
-      this.isJSONValid = false;
+  @action
+  updateJSON(evt) {
+    this.sourceJSONStr = evt.target.value;
+    this.isJSONValid = isParseable(this.sourceJSONStr);
+    if (this.isJSONValid) {
+      this.viewJSON = JSON.parse(this.sourceJSONStr);
     }
+  }
+
+  @action
+  formatSourceJSONStr() {
+    this.sourceJSONStr = JSON.stringify(this.viewJSON, null, 2);
   }
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -2,10 +2,14 @@
   <h2 id="title">Ember-JSON-Viewer</h2>
 
   <div class="viewer-wrapper">
-    <JsonViewer @json={{this.json}} @options={{hash expandedIcon=">" collapsedIcon="<" collapseDepth=1}} />
+    <JsonViewer @json={{this.viewJSON}} @options={{hash expandedIcon=">" collapsedIcon="<" collapseDepth=1}} />
   </div>
   <div class="input-wrapper {{if this.isJSONValid "valid" "invalid"}}">
     <h2>Paste JSON below:</h2>
-    <Textarea oninput={{action this.updateJSON}} @value={{json-stringify this.json}} />
+    <Textarea
+      {{on "keyup" this.updateJSON}}
+      {{on "blur" this.formatSourceJSONStr}}
+      @value={{this.sourceJSONStr}}
+    />
   </div>
 </main>


### PR DESCRIPTION
Changes component invocation to use angle-bracket invocation everywhere. The transformation was largely done by hand.

Additionally:
  * Includes template linting in `yarn lint` and fixes template lint errors
  * Changes the dummy-app's UX to be slightly easier to use (by edits to the application controller and application hbs): Before, after editing the JSON the cursor would jump to the end of the text area. Now it stays in place while you are editing