### PR TITLE
Remove this.get usage via eslint --fix

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,8 +23,6 @@ module.exports = {
     browser: true,
   },
   rules: {
-    'ember/no-get': 'off',
-    'ember/no-actions-hash': 'off',
     'ember/no-classic-classes': 'off',
     'ember/no-classic-components': 'off',
     'ember/require-tagless-components': 'off',

--- a/addon/components/entry-viewer.js
+++ b/addon/components/entry-viewer.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { action, computed } from '@ember/object';
 import layout from '../templates/components/entry-viewer';
 import { readOnly } from '@ember/object/computed';
 import { isPrimitive } from '../utils/value-types';
@@ -9,11 +9,11 @@ export default Component.extend({
   layout,
   _isExpanded: null,
   isExpanded: computed('depth', 'collapseDepth', '_isExpanded', function () {
-    if (this.get('_isExpanded') !== null) {
-      return this.get('_isExpanded');
+    if (this._isExpanded !== null) {
+      return this._isExpanded;
     }
-    let depth = this.get('depth');
-    let collapseDepth = this.get('collapseDepth');
+    let depth = this.depth;
+    let collapseDepth = this.collapseDepth;
     if (Number.isInteger(collapseDepth)) {
       return depth < collapseDepth;
     } else {
@@ -32,19 +32,17 @@ export default Component.extend({
   // It is important that this be a single text node so that the
   // selection offset is correct for copy/paste
   quotedKey: computed('key', function () {
-    return `"${this.get('key')}": `;
+    return `"${this.key}": `;
   }),
 
   isToggleable: computed('value', function () {
-    return !isPrimitive(this.get('value'));
+    return !isPrimitive(this.value);
   }),
 
-  actions: {
-    toggleExpanded() {
-      if (!this.get('isToggleable')) {
-        return;
-      }
-      this.set('_isExpanded', !this.get('isExpanded'));
-    },
-  },
+  toggleExpanded: action(function () {
+    if (!this.isToggleable) {
+      return;
+    }
+    this.set('_isExpanded', !this.isExpanded);
+  }),
 });

--- a/addon/components/json-viewer.js
+++ b/addon/components/json-viewer.js
@@ -48,7 +48,7 @@ export default Component.extend({
   json: null,
 
   displayOptions: computed('options', function () {
-    let options = this.get('options') || {};
+    let options = this.options || {};
     assert(
       `Only allowed options are: ${ALLOWED_OPTIONS}`,
       Object.keys(options).every((key) => ALLOWED_OPTIONS.includes(key)),
@@ -67,7 +67,7 @@ export default Component.extend({
         start: { path: startPath, index: startOffset },
         end: { path: endPath, index: endOffset },
       };
-      let str = jsonStringify(this.get('json'), range);
+      let str = jsonStringify(this.json, range);
       evt.clipboardData.setData('text/plain', str);
       evt.preventDefault();
     };

--- a/addon/components/simple-value.js
+++ b/addon/components/simple-value.js
@@ -9,11 +9,11 @@ export default Component.extend({
   value: null,
 
   syntaxClass: computed('type', function () {
-    return `syntax-${this.get('type')}`;
+    return `syntax-${this.type}`;
   }),
 
   type: computed('value', function () {
-    let v = this.get('value');
+    let v = this.value;
     return [true, false].includes(v)
       ? 'boolean'
       : Number.isFinite(v)
@@ -26,10 +26,10 @@ export default Component.extend({
   }),
 
   formattedValue: computed('value', 'type', function () {
-    let v = this.get('value');
-    if (this.get('type') === 'string') {
+    let v = this.value;
+    if (this.type === 'string') {
       return `"${v}"`;
-    } else if (this.get('type') === 'null') {
+    } else if (this.type === 'null') {
       return `null`;
     } else {
       return v;

--- a/addon/components/value-viewer.js
+++ b/addon/components/value-viewer.js
@@ -17,23 +17,23 @@ export default Component.extend({
   showSummary: false,
 
   isPrimitive: computed('value', function () {
-    return isPrimitive(this.get('value'));
+    return isPrimitive(this.value);
   }),
 
   prefix: computed('value', function () {
-    return isArray(this.get('value')) ? '[' : '{';
+    return isArray(this.value) ? '[' : '{';
   }),
 
   suffix: computed('value', function () {
-    return isArray(this.get('value')) ? ']' : '}';
+    return isArray(this.value) ? ']' : '}';
   }),
 
   isObj: computed('value', function () {
-    return isObject(this.get('value'));
+    return isObject(this.value);
   }),
 
   valueSummary: computed('value', function () {
-    let v = this.get('value');
+    let v = this.value;
     assert(
       `valueSummary only possible for non-primitive, got ${v}`,
       !isPrimitive(v),


### PR DESCRIPTION
Removes all usage of `this.get` by enabling the ember/no-get rule and then running `eslint . --fix`.