### PR TITLE
[breaking] Drop support for node < 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "webpack": "^5.97.1"
   },
   "engines": {
-    "node": ">= 22"
+    "node": ">= 20"
   },
   "ember": {
     "edition": "octane"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "webpack": "^5.97.1"
   },
   "engines": {
-    "node": ">= 18"
+    "node": ">= 20"
   },
   "ember": {
     "edition": "octane"
@@ -88,7 +88,7 @@
     "demoURL": "http://addepar.github.io/ember-json-viewer"
   },
   "volta": {
-    "node": "18.20.5",
+    "node": "20.18.1",
     "yarn": "1.22.22"
   }
 }

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "webpack": "^5.97.1"
   },
   "engines": {
-    "node": ">= 20"
+    "node": ">= 22"
   },
   "ember": {
     "edition": "octane"
@@ -88,7 +88,7 @@
     "demoURL": "http://addepar.github.io/ember-json-viewer"
   },
   "volta": {
-    "node": "20.18.1",
+    "node": "22.12.0",
     "yarn": "1.22.22"
   }
 }


### PR DESCRIPTION
Builds on #42 and can be merged after that one.
Relative diff is small: https://github.com/Addepar/ember-json-viewer/compare/bantic/add-embroider...bantic/upgrade-node

We just change package.json#engines to indicate support for node >= 20, and use volta to pin node to v22.
The CI now runs using node v22 because the volta github action will setup the node version that's pinned in the package.json.

I kept the engines at node >= 20 instead of >= 22 because it seems like it would be unnecessary noise for consumers using node v20 to see a "warning: requires node >= 22". As a fairly simple addon, the node version used by consumers has very little effect so I think it's better to have a wider engines range.