### PR TITLE
[fix] bug where an extra comma is added after final object

### DIFF
--- a/addon/addon/components/entry-viewer.hbs
+++ b/addon/addon/components/entry-viewer.hbs
@@ -30,7 +30,7 @@
     @displayOptions={{@displayOptions}}
     @path={{@path}}
   />
-  {{#unless this.isLast}}
+  {{#unless @isLast}}
     {{! In order for copy/paste to work, there cannot be extra whitespace around the delimiter }}
     <span class="entry-delimiter" data-path={{concat @path "@" ","}}>,</span>
   {{/unless}}

--- a/test-app/tests/integration/components/json-viewer-test.js
+++ b/test-app/tests/integration/components/json-viewer-test.js
@@ -145,4 +145,23 @@ module('Integration | Component | json-viewer', function (hooks) {
       assert.strictEqual(userSelectStyle, expected);
     }
   });
+
+  test('no comma after final object', async function (assert) {
+    this.set('json', {
+      obj: { foo: 'bar' },
+    });
+    await render(
+      hbs`<JsonViewer data-test-json-viewer-outer @json={{this.json}} />`,
+    );
+
+    assert
+      .dom('[data-path="$.obj>"]')
+      .containsText('}', 'object closing brace is present');
+    assert
+      .dom('[data-path="$.obj@,"]')
+      .doesNotExist('no comma after final object');
+    assert
+      .dom('[data-test-json-viewer-outer]')
+      .doesNotContainText(',', 'No comma appears in the output');
+  });
 });


### PR DESCRIPTION
The PR https://github.com/Addepar/ember-json-viewer/pull/53 introduced a bug when it converted `<EntryViewer>` to be a glimmer component and didn't change the `this.isLast` reference to `@isLast`, here: https://github.com/Addepar/ember-json-viewer/pull/53/files#diff-7c6ad1a893bdd5bfc2ea6e617faccaea5a1feb2fd3321c69fd1fbcd933e05144R33

That value became permanently false-y and as a result an extraneous comma delimiter is added after a final object.
This can be seen in the [deployed docs](https://opensource.addepar.com/ember-json-viewer/):

![image](https://github.com/user-attachments/assets/b6668659-2d1d-448a-9e9c-5adb969a255a)
