### PR TITLE
tests-app: Include dropped lint rules, avoid linting .node_modules.ember-try

### DIFF
--- a/docs-app/eslint.config.mjs
+++ b/docs-app/eslint.config.mjs
@@ -73,6 +73,9 @@ export default [
     plugins: {
       qunit,
     },
+    rules: {
+      ...qunit.configs.recommended.rules,
+    },
   },
   /**
    * CJS node files

--- a/test-app/eslint.config.mjs
+++ b/test-app/eslint.config.mjs
@@ -34,16 +34,22 @@ const esmParserOptions = {
 };
 
 export default [
-  // js.configs.recommended,
-  // prettier,
-  // ember.configs.base,
-  // ember.configs.gjs,
+  js.configs.recommended,
+  prettier,
+  ember.configs.base,
+  ember.configs.gjs,
   /**
    * Ignores must be in their own object
    * https://eslint.org/docs/latest/use/configure/ignore
    */
   {
-    ignores: ["dist/", "node_modules/", "coverage/", "!**/.*"],
+    ignores: [
+      "dist/",
+      "node_modules/",
+      "coverage/",
+      "!**/.*",
+      ".node_modules.ember-try/",
+    ],
   },
   /**
    * https://eslint.org/docs/latest/use/configure/configuration-files#configuring-linter-options


### PR DESCRIPTION
See https://github.com/Addepar/ember-json-viewer/pull/63#issuecomment-2583138150

In PR #63 we noticed that if there's a `.node_modules.ember-try/` dir (as a result of running `ember try` and not cleaning it up afterward), even though the dir is git ignored, eslint does not ignore it. ESLint doesn't automatically ignore files in the .gitignore.

There's a suggestion from ESLint about how to effectivley import ignore rules from gitignore here: https://eslint.org/docs/latest/use/configure/ignore

But to fix this particular case I just explicitly added `.node_modules.ember-try/` to the `ignores` list.

For reference, here is the ember addon new stock eslint config: https://github.com/ember-cli/ember-addon-output/blob/master/eslint.config.mjs

In practice I found a few issues using that stock config:
  - the qunit rules are not actually enabled by including the plugin. You also have to include the rules. This PR does that for the docs-app (it was already done for the test-app)
 
I am also a bit unclear on the `'!**/.*'` in the eslint `ignores` from the stock ember-addon config. It appears to be telling it "don't ignore dot files". I had trouble understanding the eslint v9 docs on ignoring and telling what had changed vs the v8. The v9 docs are at https://eslint.org/docs/latest/use/configure/ignore. The v8 docs (https://eslint.org/docs/v8.x/use/configure/ignore) point out that dot files (and node_modules/) were implicitly ignored (search the doc for "implicit ignore rules"). So it seems like v9 may have changed this.

At any rate, this change ensures that running `yarn lint` won't lint files in the `.node_modules.ember-try/` dir.

Additionally, this PR fixes an oversight from #63 where I had accidentally commented out some of the settings for the test-app eslint config.