### PR TITLE
workflows: Update run-tests.yml to run on merge_group trigger

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - master
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Adds `merge_group:` as an event trigger.

The GH docs specify that this must be added (https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue):

> You must use the merge_group event to trigger your GitHub Actions workflow when a pull request is added to a merge queue.