### PR TITLE
[WEBCORE-3182] Upgrade npm version to be compatible with trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      # We're using setup-node instead of the volta/setup action like the other workflows
+      # We're using setup-node instead of the volta-cli/action like the other workflows
       # in order to set reasonable defaults for the .npmrc for trusted publishing.
       # https://docs.npmjs.com/trusted-publishers#github-actions-configuration
       - uses: actions/setup-node@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,13 +46,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      # We're using setup-node instead of the volta-cli/action like the other workflows
-      # in order to set reasonable defaults for the .npmrc for trusted publishing.
-      # https://docs.npmjs.com/trusted-publishers#github-actions-configuration
-      - uses: actions/setup-node@v6
+      - uses: volta-cli/action@v5
         with:
-          # should match the version in package.json volta field
-          node-version: "22"
           registry-url: "https://registry.npmjs.org"
       - uses: pnpm/action-setup@v5
       # Both release-plan and pnpm uses `npm publish` under the hood to publish a release.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,8 +46,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: volta-cli/action@v5
+      # We're using setup-node instead of the volta/setup action like the other workflows
+      # in order to set reasonable defaults for the .npmrc for trusted publishing.
+      # https://docs.npmjs.com/trusted-publishers#github-actions-configuration
+      - uses: actions/setup-node@v6
+        with:
+          # should match the version in package.json volta field
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
       - uses: pnpm/action-setup@v5
+      # Both release-plan and pnpm uses `npm publish` under the hood to publish a release.
+      # To be compatible with npm trusted publishing, npm v11 or later must be used.
+      - run: |
+          npx npm@latest install -g npm@latest
+          npm --version
       - run: pnpm install --frozen-lockfile
       - name: npm publish
         run: NPM_CONFIG_PROVENANCE=true pnpm release-plan publish


### PR DESCRIPTION
This is (hopefully) the last tweak we need to get trusted publishing working with release-plan. The main change is to upgrade the globally installed npm to the latest version, so that it's compatible with trusted publishing.

I've been testing this using a fork, and here's a successfuly publish https://github.com/yanglinz/ember-json-viewer-publish-test/actions/runs/24100285018/job/70309478385 that's using the same setup as this PR.

https://addepar.atlassian.net/browse/WEBCORE-3182